### PR TITLE
Promote to prod environment

### DIFF
--- a/components/go-atctyqyy/overlays/prod/deployment-patch.yaml
+++ b/components/go-atctyqyy/overlays/prod/deployment-patch.yaml
@@ -12,5 +12,5 @@ spec:
   template: 
     spec:
       containers:
-      - image: quay.io/redhat-tssc/task-runner:1.7
+      - image: artifactory-docker-artifactory-jcr2.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/go-atctyqyy:github-5728aa5ab2a37e159fb98fb8d6680897bfc77d2e
         name: container-image  


### PR DESCRIPTION
This PR promotes the application to the prod environment with image: artifactory-docker-artifactory-jcr2.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/go-atctyqyy:github-5728aa5ab2a37e159fb98fb8d6680897bfc77d2e